### PR TITLE
Use gzip compression for sed to save space

### DIFF
--- a/backup.sh
+++ b/backup.sh
@@ -30,9 +30,15 @@ rm $DUMP_FILE
 # Grab it from s3 to make sure it's intact
 aws s3 cp s3://$BACKUP_BUCKET/$SERVICE_NAME/$DUMP_FILE .
 
-# Create SQL script and remove extension comments
+# Create SQL script
 pg_restore $DUMP_FILE > $RESTORE_FILE
-sed -i '/COMMENT ON EXTENSION/d' $RESTORE_FILE
+
+# Remove extensions comments without using too much disk space
+rm $DUMP_FILE
+gzip $RESTORE_FILE
+gzip -dc ${RESTORE_FILE}.gz | sed -e '/COMMENT ON EXTENSION/d' | gzip -c > ${RESTORE_FILE}-edited.gz
+mv ${RESTORE_FILE}-edited.gz ${RESTORE_FILE}.gz
+gunzip ${RESTORE_FILE}.gz
 
 # Verify the restore file isn't empty before continuing
 if [ ! -s $RESTORE_FILE ]; then


### PR DESCRIPTION
sed -i is not really "in-place" editing; it creates a temp file which can lead to disk space issues due to the large file sizes of the sql restore script and the relatively smaller disk size on the default data pipeline instances