### PR TITLE
stop downloading the dump file from s3

### DIFF
--- a/backup.sh
+++ b/backup.sh
@@ -177,15 +177,6 @@ credential_source=Ec2InstanceMetadata" > ~/.aws/config
   echo "Copying dump file to s3 bucket: s3://$BACKUP_BUCKET/$BACKUP_ENV/$SERVICE_NAME/"
   aws s3 cp --profile backup $SSE --only-show-errors $DUMP_FILE s3://$BACKUP_BUCKET/$BACKUP_ENV/$SERVICE_NAME/
 
-  # Delete the file
-  rm -f $DUMP_FILE
-  echo "...Done"
-
-  # Copy dump from s3 to restore to temp db
-  echo "Downloading dump file from s3 bucket: s3://$BACKUP_BUCKET/$BACKUP_ENV/$SERVICE_NAME/$DUMP_FILE"
-  aws s3 cp --profile backup $SSE --only-show-errors s3://$BACKUP_BUCKET/$BACKUP_ENV/$SERVICE_NAME/$DUMP_FILE .
-  echo "...Done"
-
   # Create SQL script
   echo "Expanding & removing COMMENT ON EXTENSION from dump file..."
   pg_restore $DUMP_FILE | sed -e '/COMMENT ON EXTENSION/d' > $RESTORE_FILE
@@ -196,7 +187,6 @@ credential_source=Ec2InstanceMetadata" > ~/.aws/config
     echo "Error dump file downloaded from s3 has no data"
     exit 2
   fi
-
 fi
 
 # Create the RDS restore instance


### PR DESCRIPTION
The [aws cli calculates the MD5 hash](https://docs.aws.amazon.com/cli/latest/topic/s3-faq.html) of the object before upload and confirms it on the S3 side after upload automatically for us with the `aws s3 cp` command so there's really no need to download the object again during the script.  This will allow us to remove the `GetObject` permission from the backup role that this script is assuming so there will be no entities with `GetObject` permissions to the postgres dump files in the backup account besides `root`.