### PR TITLE
cleanup before starting

### DIFF
--- a/backup.sh
+++ b/backup.sh
@@ -11,7 +11,7 @@ export AWS_DEFAULT_REGION=us-east-1
 # when the script exits
 function cleanup_stale_instances {
 
-  echo "Trap EXIT called..."
+  echo "Trap cleanup stale instances called..."
   echo "If this script exited prematurely, check stderr for the exit error message"
 
   # if restore instance exists, delete it

--- a/backup.sh
+++ b/backup.sh
@@ -9,10 +9,18 @@ export AWS_DEFAULT_REGION=us-east-1
 
 # Use trap to print the most recent error message & delete the restore instance
 # when the script exits
+function cleanup_on_exit {
+
+  echo "Trap EXIT called..."
+  echo "If this script exited prematurely, check stderr for the exit error message"
+
+  cleanup_stale_instances
+}
+
+# generic cleanup w/error trapping
 function cleanup_stale_instances {
 
   echo "Trap cleanup stale instances called..."
-  echo "If this script exited prematurely, check stderr for the exit error message"
 
   # if restore instance exists, delete it
   ERROR=$(aws rds describe-db-instances --db-instance-identifier $DB_INSTANCE_IDENTIFIER 2>&1)
@@ -33,7 +41,7 @@ function cleanup_stale_instances {
 
 }
 
-trap cleanup_stale_instances EXIT
+trap cleanup_on_exit EXIT
 
 # call sqlcmd with retries/backoff so it doesn't fail right away after just one attempt
 function sqlcmd_with_backoff {

--- a/backup.sh
+++ b/backup.sh
@@ -9,7 +9,7 @@ export AWS_DEFAULT_REGION=us-east-1
 
 # Use trap to print the most recent error message & delete the restore instance
 # when the script exits
-function cleanup_on_exit {
+function cleanup_stale_instances {
 
   echo "Trap EXIT called..."
   echo "If this script exited prematurely, check stderr for the exit error message"
@@ -33,7 +33,7 @@ function cleanup_on_exit {
 
 }
 
-trap cleanup_on_exit EXIT
+trap cleanup_stale_instances EXIT
 
 # call sqlcmd with retries/backoff so it doesn't fail right away after just one attempt
 function sqlcmd_with_backoff {
@@ -204,6 +204,9 @@ if [[ $RDS_INSTANCE_TYPE != "db.t2.micro" ]]; then
 else
   ENCRYPTION=""
 fi
+
+# We need to make sure there isn't an instance hanging around already
+cleanup_stale_instances 
 
 echo "Create DB restore instance..."
 


### PR DESCRIPTION
We want to cleanup stale instances before we start a new one up - otherwise we'll forever be in a bad state.


![pushbroom1](https://user-images.githubusercontent.com/1489440/44045754-64b35fa8-9ede-11e8-8b59-876e4c411a43.gif)
