### PR TITLE
improve the error catching

### DIFF
--- a/backup.sh
+++ b/backup.sh
@@ -30,13 +30,13 @@ function cleanup_stale_instances {
     echo "Deleting restore DB instance $DB_INSTANCE_IDENTIFIER..."
     ERROR=$(aws rds delete-db-instance --db-instance-identifier $DB_INSTANCE_IDENTIFIER \
       --skip-final-snapshot 2>&1)
-    RET_CODE=$?
+    DELETE_RET_CODE=$?
   fi
 
   # this if statement is a catch all for any errors with the restore instance db deletion
-  if [[ $RET_CODE != 0 ]]; then
+  if [[ $DELETE_RET_CODE != 0 ]]; then
     echo $ERROR
-    exit $RET_CODE
+    exit $DELETE_RET_CODE
   fi
 
 }


### PR DESCRIPTION
So it turns out that when you ask the script to delete an instance that DOESN'T exist, it'll throw you into a funny loop and exit prematurely.

This change will catch stale instances as well as problems deleting instances, and should allow us to continue on correctly with backing up.

