### PR TITLE
Allow cluster deletion if 0 instances

### DIFF
--- a/psql-backups.sh
+++ b/psql-backups.sh
@@ -2,7 +2,8 @@
 
 # AWS Data Pipeline RDS backup and verification automation relying on Amazon Linux and S3
 
-# exit immediately if a command exit code is not 0 or a variable is undefined
+# Ensure the return value of a pipeline is the last command to exit with a non-zero status, 
+# or zero if all commands in were successful, and exit if a variable is undefined.
 set -uo pipefail
 
 export AWS_DEFAULT_REGION=$AWS_REGION
@@ -27,6 +28,7 @@ function cleanup_on_exit {
   fi
   
   # this if statement is a catch all for any errors with the restore instance db deletion
+  # except when a DBInstance is not found, so we can still delete the cluster if it exists
   if [[ $RET_CODE != 0 && ! $ERROR =~ "An error occurred (DBInstanceNotFound)" ]]; then
     echo $ERROR
     exit $RET_CODE

--- a/psql-backups.sh
+++ b/psql-backups.sh
@@ -3,7 +3,7 @@
 # AWS Data Pipeline RDS backup and verification automation relying on Amazon Linux and S3
 
 # exit immediately if a command exit code is not 0 or a variable is undefined
-set -euo pipefail
+set -uo pipefail
 
 export AWS_DEFAULT_REGION=$AWS_REGION
 
@@ -27,7 +27,7 @@ function cleanup_on_exit {
   fi
   
   # this if statement is a catch all for any errors with the restore instance db deletion
-  if [[ $RET_CODE != 0 ]]; then
+  if [[ $RET_CODE != 0 && ! $ERROR =~ "An error occurred (DBInstanceNotFound)" ]]; then
     echo $ERROR
     exit $RET_CODE
   fi


### PR DESCRIPTION
Removes the -e from set to allow the script to continue on error and adds a condition to allow the script to continue when the DB instance is not found