### PR TITLE
removing -N from pg_dumpall in version 10+

### DIFF
--- a/psql-backups-iam-auth.sh
+++ b/psql-backups-iam-auth.sh
@@ -97,7 +97,7 @@ if [[ "$IAM_AUTH_ENABLED" == "true" ]]; then
     if [[ "$majorVersion" == "9" ]]; then
         pg_dump -Fc -h $RDS_ENDPOINT -U $RDS_IAM_AUTH_USERNAME -d $DB_NAME -f $DUMP_FILE -N apgcc
     else
-        pg_dumpall --globals-only -U $RDS_IAM_AUTH_USERNAME -h $RDS_ENDPOINT -f $DUMP_FILE -N apgcc
+        pg_dumpall --globals-only -U $RDS_IAM_AUTH_USERNAME -h $RDS_ENDPOINT -f $DUMP_FILE
     fi
 else
     echo "Connect via username and password..."
@@ -106,7 +106,7 @@ else
     if [[ "$majorVersion" == "9" ]]; then
         pg_dump -Fc -h $RDS_ENDPOINT -U $RDS_USERNAME -d $DB_NAME -f $DUMP_FILE -N apgcc
     else
-        pg_dumpall --globals-only -U $RDS_USERNAME -h $RDS_ENDPOINT -f $DUMP_FILE -N apgcc
+        pg_dumpall --globals-only -U $RDS_USERNAME -h $RDS_ENDPOINT -f $DUMP_FILE
     fi
 fi
 

--- a/psql-backups.sh
+++ b/psql-backups.sh
@@ -91,7 +91,7 @@ export PGPASSWORD=$RDS_PASSWORD
 if [[ "$majorVersion" == "9" ]]; then
   pg_dump -Fc -h $RDS_ENDPOINT -U $RDS_USERNAME -d $DB_NAME -f $DUMP_FILE -N apgcc
 else 
-  pg_dumpall --globals-only -U $RDS_USERNAME -h $RDS_ENDPOINT -f $DUMP_FILE -N apgcc
+  pg_dumpall --globals-only -U $RDS_USERNAME -h $RDS_ENDPOINT -f $DUMP_FILE
 fi
 echo "...Done"
 


### PR DESCRIPTION
In [version 10+](https://www.postgresql.org/docs/12/app-pg-dumpall.html) `pg_dumpall` no longer supports `-N <schema>` 

We're removing this