### PR TITLE
Fix USE_BACKUPS_ACCOUNT check to work if variable not passed in

### DIFF
--- a/backup.sh
+++ b/backup.sh
@@ -85,11 +85,11 @@ DUMP=$SERVICE_NAME-$(date +%Y_%m_%d_%H%M%S)
 RESTORE_FILE=restore.sql
 SSE="--sse aws:kms --sse-kms-key-id $KMS_KEY"
 
-if [[ $USE_BACKUPS_ACCOUNT == "false" ]]
+if [[ ${USE_BACKUPS_ACCOUNT:-true} == "true" ]]
 then
-  PROFILE_ARG=""
-else
   PROFILE_ARG="--profile backup"
+else
+  PROFILE_ARG=""
 fi
 
 mkdir -p ~/.aws

--- a/psql-backups-iam-auth.sh
+++ b/psql-backups-iam-auth.sh
@@ -67,11 +67,11 @@ DB_INSTANCE_IDENTIFIER=$DB_ENGINE-$SERVICE_NAME-auto-restore
 DUMP=$SERVICE_NAME-$(date +%Y_%m_%d_%H%M%S)
 RESTORE_FILE=restore.sql
 
-if [[ $USE_BACKUPS_ACCOUNT == "false" ]]
+if [[ ${USE_BACKUPS_ACCOUNT:-true} == "true" ]]
 then
-  PROFILE_ARG=""
-else
   PROFILE_ARG="--profile backup"
+else
+  PROFILE_ARG=""
 fi
 
 mkdir -p ~/.aws

--- a/psql-backups.sh
+++ b/psql-backups.sh
@@ -67,11 +67,11 @@ DB_INSTANCE_IDENTIFIER=$DB_ENGINE-$SERVICE_NAME-auto-restore
 DUMP=$SERVICE_NAME-$(date +%Y_%m_%d_%H%M%S)
 RESTORE_FILE=restore.sql
 
-if [[ $USE_BACKUPS_ACCOUNT == "false" ]]
+if [[ ${USE_BACKUPS_ACCOUNT:-true} == "true" ]]
 then
-  PROFILE_ARG=""
-else
   PROFILE_ARG="--profile backup"
+else
+  PROFILE_ARG=""
 fi
 
 mkdir -p ~/.aws


### PR DESCRIPTION
Because we have `set -uo pipefail` set we need to be explict on what the value of `USE_BACKUPS_ACCOUNT` is set to if it is not passed in.