### PR TITLE
Updating PG version check

### DIFF
--- a/backup.sh
+++ b/backup.sh
@@ -184,12 +184,23 @@ else # Our default db is Postgres
   get_time_now
   echo "$time_now Postgres dump. Installing dependencies..."
 
-  if [[ $majorVersion -ge 10 ]]; then
-    # we use the amazon-linux-2 AMI for postgres versions 10 and 11
+  if [[ $majorVersion -ge 12 ]]; then
+    # amazon-linux-2 doesn't have postgresql packages above V11.
+    sudo tee /etc/yum.repos.d/pgdg.repo<<EOF
+[pgdg$PSQL_TOOLS_VERSION]
+name=PostgreSQL $PSQL_TOOLS_VERSION for RHEL/CentOS 7 - x86_64
+baseurl=https://download.postgresql.org/pub/repos/yum/$PSQL_TOOLS_VERSION/redhat/rhel-7-x86_64"
+enabled=1
+gpgcheck=0
+EOF
+    sudo yum makecache
+    sudo yum install "postgresql${PSQL_TOOLS_VERSION}"
+  elif [[ $majorVersion -ge 10 ]] && [[ $majorVersion -lt 12 ]]; then
+    # we use the amazon-linux-2 AMI for postgres versions 10 and above
     # so install the postgresql package using amazon-linux-extras
-    sudo amazon-linux-extras install -y postgresql$majorVersion > /dev/null
+    sudo amazon-linux-extras install -y "postgresql${PSQL_TOOLS_VERSION}" > /dev/null
   else
-    sudo yum install -y postgresql$PSQL_TOOLS_VERSION > /dev/null
+    sudo yum install -y "postgresql${PSQL_TOOLS_VERSION}" > /dev/null
   fi
 
   get_time_now

--- a/backup.sh
+++ b/backup.sh
@@ -184,7 +184,7 @@ else # Our default db is Postgres
   get_time_now
   echo "$time_now Postgres dump. Installing dependencies..."
 
-  if [[ "$majorVersion" == "10" || "$majorVersion" == "11" ]]; then
+  if [[ $majorVersion -ge 10 ]]; then
     # we use the amazon-linux-2 AMI for postgres versions 10 and 11
     # so install the postgresql package using amazon-linux-extras
     sudo amazon-linux-extras install -y postgresql$majorVersion > /dev/null

--- a/psql-backups-iam-auth.sh
+++ b/psql-backups-iam-auth.sh
@@ -95,8 +95,23 @@ aws configure set s3.signature_version s3v4
 
 # Install the postgres tools matching the engine version
 get_time_now
-echo "$time_now Postgres dump. installing dependencies..."
-sudo amazon-linux-extras install -y postgresql$PSQL_TOOLS_VERSION > /dev/null
+echo "$time_now Postgres dump. installing dependencies for postgresql$PSQL_TOOLS_VERSION ..."
+
+if [[ $majorVersion -ge 12 ]]; then
+  # amazon-linux-2 doesn't have postgresql packages above V11.
+  sudo tee /etc/yum.repos.d/pgdg.repo<<EOF
+[pgdg$PSQL_TOOLS_VERSION]
+name=PostgreSQL $PSQL_TOOLS_VERSION for RHEL/CentOS 7 - x86_64
+baseurl=https://download.postgresql.org/pub/repos/yum/$PSQL_TOOLS_VERSION/redhat/rhel-7-x86_64
+enabled=1
+gpgcheck=0
+EOF
+  sudo yum makecache
+  sudo yum install postgresql$PSQL_TOOLS_VERSION 
+else
+  sudo amazon-linux-extras install -y postgresql$PSQL_TOOLS_VERSION > /dev/null
+fi
+
 get_time_now
 echo "$time_now ...Done"
 

--- a/psql-backups-iam-auth.sh
+++ b/psql-backups-iam-auth.sh
@@ -102,14 +102,14 @@ if [[ $majorVersion -ge 12 ]]; then
   sudo tee /etc/yum.repos.d/pgdg.repo<<EOF
 [pgdg$PSQL_TOOLS_VERSION]
 name=PostgreSQL $PSQL_TOOLS_VERSION for RHEL/CentOS 7 - x86_64
-baseurl=https://download.postgresql.org/pub/repos/yum/$PSQL_TOOLS_VERSION/redhat/rhel-7-x86_64
+baseurl=https://download.postgresql.org/pub/repos/yum/$PSQL_TOOLS_VERSION/redhat/rhel-7-x86_64"
 enabled=1
 gpgcheck=0
 EOF
   sudo yum makecache
-  sudo yum install postgresql$PSQL_TOOLS_VERSION 
+  sudo yum install "postgresql${PSQL_TOOLS_VERSION}"
 else
-  sudo amazon-linux-extras install -y postgresql$PSQL_TOOLS_VERSION > /dev/null
+  sudo amazon-linux-extras install -y "postgresql${PSQL_TOOLS_VERSION}" > /dev/null
 fi
 
 get_time_now

--- a/psql-backups-iam-auth.sh
+++ b/psql-backups-iam-auth.sh
@@ -84,7 +84,7 @@ majorVersion="${DB_ENGINE_VERSION%%.*}"
 PSQL_TOOLS_VERSION=$(echo $DB_ENGINE_VERSION | awk -F\. '{print $1"."$2}')
 
 # package name changed 10 on
-if [[ "$majorVersion" == "10" || "$majorVersion" == "11" ]]; then
+if [[ $majorVersion -ge 10 ]]; then
   PSQL_TOOLS_VERSION="$majorVersion"
 fi
 

--- a/psql-backups.sh
+++ b/psql-backups.sh
@@ -96,10 +96,24 @@ aws configure set s3.signature_version s3v4
 # Install the postgres tools matching the engine version
 get_time_now
 echo "$time_now Postgres dump. installing dependencies..."
-
-sudo amazon-linux-extras install -y postgresql$PSQL_TOOLS_VERSION > /dev/null
+if [[ $majorVersion -ge 12 ]]; then
+  # amazon-linux-2 doesn't have postgresql packages above V11.
+  sudo tee /etc/yum.repos.d/pgdg.repo<<EOF
+[pgdg$PSQL_TOOLS_VERSION]
+name=PostgreSQL $PSQL_TOOLS_VERSION for RHEL/CentOS 7 - x86_64
+baseurl=https://download.postgresql.org/pub/repos/yum/$PSQL_TOOLS_VERSION/redhat/rhel-7-x86_64"
+enabled=1
+gpgcheck=0
+EOF
+  sudo yum makecache
+  sudo yum install "postgresql${PSQL_TOOLS_VERSION}"
+else
+  sudo amazon-linux-extras install -y "postgresql${PSQL_TOOLS_VERSION}" > /dev/null
+fi
 get_time_now
 echo "$time_now ...Done"
+
+
 
 
 # Take the backup

--- a/psql-backups.sh
+++ b/psql-backups.sh
@@ -84,7 +84,7 @@ majorVersion="${DB_ENGINE_VERSION%%.*}"
 PSQL_TOOLS_VERSION=$(echo $DB_ENGINE_VERSION | awk -F\. '{print $1"."$2}')
 
 # package name changed 10 on
-if [[ "$majorVersion" == "10" || "$majorVersion" == "11" ]]; then
+if [[ $majorVersion -ge 10 ]]; then
   PSQL_TOOLS_VERSION="$majorVersion"
 fi
 


### PR DESCRIPTION
Current logic for checking postgres version only accounts for 10 and 11. I believe this logic
will account for 10 and up.

```
bash-3.2$ majorVersion="9"; if [[ $majorVersion -ge 10 ]]; then echo $majorVersion; fi
bash-3.2$ majorVersion="10"; if [[ $majorVersion -ge 10 ]]; then echo $majorVersion; fi
10
bash-3.2$ majorVersion="11"; if [[ $majorVersion -ge 10 ]]; then echo $majorVersion; fi
11
bash-3.2$ majorVersion="12"; if [[ $majorVersion -ge 10 ]]; then echo $majorVersion; fi
12
```


Install postgres manually for versions >= 12. 