### PR TITLE
Now that we're using the default backup images, use python 3 pip, install dependencies

### DIFF
--- a/backup.sh
+++ b/backup.sh
@@ -112,8 +112,10 @@ if [[ $DB_ENGINE == "sqlserver-se" ]]; then
 
   # Install sqlcmd microsoft client libs & cvskit
   echo "Sqlserver dump. installing dependencies..."
-  sudo pip install --upgrade six > /dev/null
-  sudo pip install csvkit > /dev/null
+  sudo yum -y -q update
+  sudo yum install -y -q python3-pip libicu-devel gcc gcc-c++ python3-devel
+  sudo pip3 install --upgrade six > /dev/null
+  sudo pip3 install csvkit > /dev/null
   curl -s https://packages.microsoft.com/keys/microsoft.asc | tee /tmp/microsoft.asc > /dev/null
   sudo rpm --quiet --import /tmp/microsoft.asc
   curl -s https://packages.microsoft.com/config/rhel/6/prod.repo \


### PR DESCRIPTION
The old, hardcoded image (ami-087d13da21e69d784) installed these things for us, but
now the version of pip is too old (likely because of the python 2 deprecation), and errors
with:

You are using pip version 9.0.1, however version 21.0.1 is available. You should consider upgrading via the 'pip install --upgrade pip' command.
Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-build-ZfqZQJ/PyICU/ You are using pip version 9.0.1, however version 21.0.1 is available. You should consider upgrading via the 'pip install --upgrade pip' command.

This PR makes these pip packages install correctly on the latest generic backups ami.