### PR TITLE
9.6 end of life

### DIFF
--- a/backup.sh
+++ b/backup.sh
@@ -219,8 +219,8 @@ EOF
   # shellcheck disable=SC2086
   aws s3 cp $PROFILE_ARG $SSE --only-show-errors "$DUMP_FILE" "s3://${BACKUP_BUCKET}/${BACKUP_ENV}/${SERVICE_NAME}/"
 
-  if [[ "$majorVersion" < "10" ]]; then 
-    _log "Engine version is < 10. Skipping restore test..."
+  if [[ "$majorVersion" -lt "10" ]]; then 
+    _log "Engine version is below 10. Skipping restore test..."
 
     # Check in on success
     _log "Checkin to snitch..."

--- a/psql-backups-iam-auth.sh
+++ b/psql-backups-iam-auth.sh
@@ -128,8 +128,8 @@ _log "Copying dump file to s3 bucket: s3://$BACKUPS_BUCKET/$SERVICE_NAME/rds/"
 # shellcheck disable=SC2086
 aws s3 cp $PROFILE_ARG --region "$BACKUPS_BUCKET_REGION" --only-show-errors "$DUMP_FILE" "s3://${BACKUPS_BUCKET}/${SERVICE_NAME}/rds/"
 
-if [[ "$majorVersion" < "10" ]]; then 
-  _log "Engine version is < 10. Skipping restore test..."
+if [[ "$majorVersion"  -lt "10" ]]; then 
+  _log "Engine version is below 10. Skipping restore test..."
 
   # Check in on success
   _log "Checkin to snitch..."

--- a/psql-backups.sh
+++ b/psql-backups.sh
@@ -122,8 +122,8 @@ _log "Copying dump file to s3 bucket: s3://$BACKUPS_BUCKET/$SERVICE_NAME/rds/"
 # shellcheck disable=SC2086
 aws s3 cp $PROFILE_ARG --region "$BACKUPS_BUCKET_REGION" --only-show-errors "$DUMP_FILE" "s3://${BACKUPS_BUCKET}/${SERVICE_NAME}/rds/"
 
-if [[ "$majorVersion" < "10" ]]; then 
-  _log "Engine version is < 10. Skipping restore test..."
+if [[ "$majorVersion" -lt "10" ]]; then 
+  _log "Engine version is below 10. Skipping restore test..."
 
   # Check in on success
   _log "Checkin to snitch..."


### PR DESCRIPTION
We cannot do a restore test on aurora-postgres databases that use engine versions < 10 (as we cannot create the test restore DB cluster), so we should skip that step of the backup process for those databases while they are being upgraded. 

Relevant slack link: https://articulate.slack.com/archives/C02K5UDLEFL/p1635300553021600