### PR TITLE
Do not restore user privileges in older backup.sh script

### DIFF
--- a/backup.sh
+++ b/backup.sh
@@ -207,7 +207,7 @@ EOF
   # Take the backup
   _log "Taking the backup..."
   export PGPASSWORD=$RDS_PASSWORD
-  pg_dump -Fc -h --no-privileges "$RDS_ENDPOINT" -U "$RDS_USERNAME" -d "$DB_NAME" -f "$DUMP_FILE" -N apgcc
+  pg_dump -Fc -h "$RDS_ENDPOINT" -U "$RDS_USERNAME" -d "$DB_NAME" -f "$DUMP_FILE" -N apgcc
   _log "...Done"
 
 
@@ -372,7 +372,7 @@ if [[ $DB_ENGINE == "sqlserver-se" ]]; then
 else # Restore Postgres db
   _log "Restoring Postgres backup..."
   pg_restore -l "$DUMP_FILE" | grep -v 'COMMENT - EXTENSION' > pg_restore.list
-  pg_restore --exit-on-error -h "$RESTORE_ENDPOINT" -U "$RDS_USERNAME" -d "$DB_NAME" -L pg_restore.list "$DUMP_FILE"
+  pg_restore --exit-on-error -x -h "$RESTORE_ENDPOINT" -U "$RDS_USERNAME" -d "$DB_NAME" -L pg_restore.list "$DUMP_FILE"
   _log "...Done"
 fi
 

--- a/backup.sh
+++ b/backup.sh
@@ -207,7 +207,7 @@ EOF
   # Take the backup
   _log "Taking the backup..."
   export PGPASSWORD=$RDS_PASSWORD
-  pg_dump -Fc -h "$RDS_ENDPOINT" -U "$RDS_USERNAME" -d "$DB_NAME" -f "$DUMP_FILE" -N apgcc
+  pg_dump -Fc -h --no-privileges "$RDS_ENDPOINT" -U "$RDS_USERNAME" -d "$DB_NAME" -f "$DUMP_FILE" -N apgcc
   _log "...Done"
 
 


### PR DESCRIPTION
This is already something we handle in the newer psql specific backup scripts. https://github.com/articulate/datapipeline-scripts/blob/642fc03cc26f08180599c0216121c4a15fc39a89/psql-backups-iam-auth.sh#L145 


Slack thread for context: https://articulate.slack.com/archives/C046MNLGH/p1636417101048200?thread_ts=1636416015.047800&cid=C046MNLGH 